### PR TITLE
Add postcode connector (kindtech.postcodes)

### DIFF
--- a/docs/api/data-sources.md
+++ b/docs/api/data-sources.md
@@ -255,20 +255,8 @@ wrappers are community-built:
 
 [postcodes.io](https://postcodes.io/) is a free, open-source REST API that
 resolves UK postcodes to administrative and statistical geographies. KindTech's
-`postcodes` module wraps it so client address data joins to the same
+`postcodes` module wraps it so address data joins to the same
 `geography_code` used by the geo and ONS modules.
-
-### Why a third-party API (not ONS directly)
-
-ONS publishes the underlying data — the
-[ONS Postcode Directory (ONSPD)](https://geoportal.statistics.gov.uk/datasets/ons::ons-postcode-directory-may-2024/about)
-and
-[National Statistics Postcode Lookup (NSPL)](https://geoportal.statistics.gov.uk/datasets/national-statistics-postcode-lookup-2021-census/about)
-— but only as bulk ZIP downloads of ~2.6 million postcodes (hundreds of MB),
-which is too large to ship in the package. postcodes.io is built on exactly
-these products (plus Ordnance Survey Open Names and the Scottish Postcode
-Directory) and serves per-postcode lookups over HTTP, so KindTech can stay a
-thin wrapper with no bundled data and no ingestion step.
 
 ### Endpoints
 

--- a/docs/api/data-sources.md
+++ b/docs/api/data-sources.md
@@ -251,6 +251,68 @@ wrappers are community-built:
 
 ---
 
+## postcodes.io
+
+[postcodes.io](https://postcodes.io/) is a free, open-source REST API that
+resolves UK postcodes to administrative and statistical geographies. KindTech's
+`postcodes` module wraps it so client address data joins to the same
+`geography_code` used by the geo and ONS modules.
+
+### Why a third-party API (not ONS directly)
+
+ONS publishes the underlying data — the
+[ONS Postcode Directory (ONSPD)](https://geoportal.statistics.gov.uk/datasets/ons::ons-postcode-directory-may-2024/about)
+and
+[National Statistics Postcode Lookup (NSPL)](https://geoportal.statistics.gov.uk/datasets/national-statistics-postcode-lookup-2021-census/about)
+— but only as bulk ZIP downloads of ~2.6 million postcodes (hundreds of MB),
+which is too large to ship in the package. postcodes.io is built on exactly
+these products (plus Ordnance Survey Open Names and the Scottish Postcode
+Directory) and serves per-postcode lookups over HTTP, so KindTech can stay a
+thin wrapper with no bundled data and no ingestion step.
+
+### Endpoints
+
+Base URL: `https://api.postcodes.io`
+
+| Endpoint | Description |
+|---|---|
+| `POST /postcodes` | Bulk lookup, up to **100 postcodes** per request |
+| `GET /postcodes/{postcode}` | Single postcode lookup |
+| `GET /postcodes?lon={lon}&lat={lat}` | Reverse geocode — nearest postcodes to a point |
+| `GET /outcodes/{outcode}` | Outcode info: spanned Local Authorities + centroid |
+
+No authentication is required. KindTech batches bulk lookups at 100 per request
+and preserves input order.
+
+### Returned geography codes
+
+A postcode lookup returns a `codes` object with standard ONS GSS codes.
+KindTech surfaces these aligned to its geography types:
+
+| KindTech level | postcodes.io `codes` key | Example |
+|---|---|---|
+| LSOA | `lsoa21` | `E01034394` |
+| MSOA | `msoa21` | `E02007008` |
+| OA | `oa21` | `E00182613` |
+| LAD | `admin_district` | `E09000023` |
+| WD (ward) | `admin_ward` | `E05013727` |
+| ICB | `icb` | `E54000030` |
+| TTWA | `ttwa` | `E30000234` |
+
+2021 Census geographies (`lsoa21`, `msoa21`, `oa21`) are preferred so codes
+match Census 2021 statistics and current boundary data.
+
+### Licensing
+
+postcodes.io code is MIT licensed; the underlying data is
+[Open Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/),
+containing OS data © Crown copyright and database right, Royal Mail data
+© Royal Mail copyright and database right, and National Statistics data
+© Crown copyright and database right. Maintained by
+[Ideal Postcodes](https://ideal-postcodes.co.uk/).
+
+---
+
 ## Dataset Aliases
 
 Instead of remembering NOMIS dataset IDs like `NM_2002_1`, you can use

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -29,14 +29,14 @@ df = load_ons("NM_1_1", geography="TYPE480", time="latest")
 ### [Postcodes](postcodes.md) — `kindtech.postcodes`
 
 Resolve UK postcodes (and outcodes) to ONS geography codes via postcodes.io, so
-client address data joins to boundaries and statistics. Returns pandas or polars
+address data joins to boundaries and statistics. Returns pandas or polars
 DataFrames.
 
 ```python
 from kindtech.postcodes import postcodes_to_geography
 
 # Postcodes -> LSOA, ready to join on `geography_code`
-clients = postcodes_to_geography(["SE13 7HX", "SE6 4RU"], geography_type="LSOA")
+located = postcodes_to_geography(["SE13 7HX", "SE6 4RU"], geography_type="LSOA")
 ```
 
 ## Design principles

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,6 +1,6 @@
 # API Reference
 
-KindTech provides two modules for accessing UK public data:
+KindTech provides three modules for accessing UK public data:
 
 ## Modules
 
@@ -24,6 +24,19 @@ from kindtech.ons import load_ons
 
 # Load Jobseeker's Allowance data
 df = load_ons("NM_1_1", geography="TYPE480", time="latest")
+```
+
+### [Postcodes](postcodes.md) — `kindtech.postcodes`
+
+Resolve UK postcodes (and outcodes) to ONS geography codes via postcodes.io, so
+client address data joins to boundaries and statistics. Returns pandas or polars
+DataFrames.
+
+```python
+from kindtech.postcodes import postcodes_to_geography
+
+# Postcodes -> LSOA, ready to join on `geography_code`
+clients = postcodes_to_geography(["SE13 7HX", "SE6 4RU"], geography_type="LSOA")
 ```
 
 ## Design principles

--- a/docs/api/postcodes.md
+++ b/docs/api/postcodes.md
@@ -18,7 +18,7 @@ Map postcodes to a single geography level, ready to join.
 ```python
 from kindtech import postcodes_to_geography
 
-clients = postcodes_to_geography(["SE13 7HX", "SE6 4RU"], geography_type="LSOA")
+located = postcodes_to_geography(["SE13 7HX", "SE6 4RU"], geography_type="LSOA")
 #    postcode geography_code geography_name
 # 0  SE13 7HX      E01034394  Lewisham 040C
 # 1   SE6 4RU      E01003318  Lewisham 020B
@@ -32,9 +32,9 @@ result merges directly:
 import pandas as pd
 from kindtech import postcodes_to_geography, load_geodata, load_ons, geodata_to_properties
 
-# 1. Clients -> LSOA counts
-clients = postcodes_to_geography(client_postcodes, "LSOA")
-per_lsoa = clients.groupby("geography_code").size().reset_index(name="clients")
+# 1. Postcodes -> counts per LSOA
+located = postcodes_to_geography(postcodes, "LSOA")
+per_lsoa = located.groupby("geography_code").size().reset_index(name="count")
 
 # 2. Population for per-capita, and boundaries for the map — same join key
 pop = load_ons("population_lsoa", geography_type="LSOA", time="latest")
@@ -100,7 +100,7 @@ outcode_to_geography(["SE13"], geography_type="LSOA")
 !!! warning "Outcode mapping is approximate"
     An outcode covers many LSOAs/wards. This returns the geography *containing
     the outcode's geometric centroid* — a rough stand-in, useful when your data
-    is only tagged by postcode prefix. For per-area analysis (e.g. referrals
+    is only tagged by postcode prefix. For per-area analysis (e.g. counts
     per capita by LSOA), prefer full postcodes via `postcodes_to_geography()`,
     or split an outcode's records across its constituent areas weighted by
     population.

--- a/docs/api/postcodes.md
+++ b/docs/api/postcodes.md
@@ -1,0 +1,117 @@
+# Postcodes
+
+The `kindtech.postcodes` module turns UK postcodes (and postcode outcodes) into
+the ONS geography codes the rest of KindTech joins on. It wraps
+[postcodes.io](https://postcodes.io/) — no API key required.
+
+This is the missing link for charity client data: a list of client postcodes
+becomes a `geography_code` column that joins straight to boundaries
+([`load_geodata`](geo.md)) and statistics ([`load_ons`](ons.md)).
+
+## Functions
+
+### `postcodes_to_geography()`
+
+Map postcodes to a single geography level, ready to join.
+
+```python
+from kindtech import postcodes_to_geography
+
+clients = postcodes_to_geography(["SE13 7HX", "SE6 4RU"], geography_type="LSOA")
+#    postcode geography_code geography_name
+# 0  SE13 7HX      E01034394  Lewisham 040C
+# 1   SE6 4RU      E01003318  Lewisham 020B
+```
+
+Returns columns `postcode`, `geography_code`, `geography_name`. The
+`geography_code` aligns with `geodata_to_properties()` and `load_ons()`, so the
+result merges directly:
+
+```python
+import pandas as pd
+from kindtech import postcodes_to_geography, load_geodata, load_ons, geodata_to_properties
+
+# 1. Clients -> LSOA counts
+clients = postcodes_to_geography(client_postcodes, "LSOA")
+per_lsoa = clients.groupby("geography_code").size().reset_index(name="clients")
+
+# 2. Population for per-capita, and boundaries for the map — same join key
+pop = load_ons("population_lsoa", geography_type="LSOA", time="latest")
+geo = pd.DataFrame(geodata_to_properties(load_geodata("LSOA"), "LSOA", 2021))
+
+merged = geo.merge(per_lsoa, on="geography_code", how="left").merge(
+    pop, on="geography_code", how="left"
+)
+```
+
+Supported `geography_type` values: `LSOA`, `MSOA`, `OA`, `LAD`, `WD`, `ICB`,
+`TTWA` (string or [`GeographyType`](geo.md) enum). An unsupported level raises
+`ValueError`.
+
+### `lookup_postcodes()`
+
+The full lookup — one row per postcode with every geography level at once.
+
+```python
+from kindtech import lookup_postcodes
+
+df = lookup_postcodes(["SE13 7HX", "M1 1AE", "NOTAPC"])
+```
+
+Columns: `postcode`, `valid`, `lsoa_code`/`lsoa_name`, `msoa_code`/`msoa_name`,
+`oa_code`, `lad_code`/`lad_name`, `ward_code`, `icb_code`, `ttwa_code`,
+`latitude`, `longitude`.
+
+!!! note "Invalid postcodes are flagged, not dropped"
+    Unrecognised postcodes return a row with `valid=False` and `None` codes, so
+    the output always lines up with the input. Filter with
+    `df[df["valid"]]` when you only want matches.
+
+### `lookup_outcodes()`
+
+Look up postcode **outcodes** — the prefix before the space (e.g. `SE13`). An
+outcode spans many areas, so this returns the *list* of Local Authorities it
+touches plus the outcode's geometric centroid.
+
+```python
+from kindtech import lookup_outcodes
+
+lookup_outcodes(["SE13", "M1"])
+#   outcode  valid      admin_districts   latitude  longitude
+# 0    SE13   True  Greenwich, Lewisham  51.459641  -0.009665
+```
+
+Columns: `outcode`, `valid`, `admin_districts` (comma-separated LAD names),
+`latitude`, `longitude`.
+
+### `outcode_to_geography()`
+
+Approximate an outcode to a single geography via its centroid.
+
+```python
+from kindtech import outcode_to_geography
+
+outcode_to_geography(["SE13"], geography_type="LSOA")
+#   outcode geography_code geography_name
+# 0    SE13      E01033327  Lewisham 041B
+```
+
+!!! warning "Outcode mapping is approximate"
+    An outcode covers many LSOAs/wards. This returns the geography *containing
+    the outcode's geometric centroid* — a rough stand-in, useful when your data
+    is only tagged by postcode prefix. For per-area analysis (e.g. referrals
+    per capita by LSOA), prefer full postcodes via `postcodes_to_geography()`,
+    or split an outcode's records across its constituent areas weighted by
+    population.
+
+## Design
+
+`kindtech.postcodes` is a thin runtime wrapper — unlike the `geo` and `ons`
+modules it ships no catalog and has no ingestion step, because postcodes.io
+serves the lookup directly. Requests are batched (100 postcodes per call, the
+postcodes.io limit) and results preserve input order. DataFrames come back in
+whatever backend you have installed (pandas or polars), like the rest of
+KindTech.
+
+See [Data Sources](data-sources.md#postcodesio) for the underlying datasets,
+licensing, and limits.

--- a/docs/api/postcodes.md
+++ b/docs/api/postcodes.md
@@ -4,8 +4,9 @@ The `kindtech.postcodes` module turns UK postcodes (and postcode outcodes) into
 the ONS geography codes the rest of KindTech joins on. It wraps
 [postcodes.io](https://postcodes.io/) — no API key required.
 
-This is the missing link for charity client data: a list of client postcodes
-becomes a `geography_code` column that joins straight to boundaries
+It's the layer that connects point-level address data to the common geography
+types: any list of postcodes becomes a `geography_code` column — at LSOA, MSOA,
+OA, LAD, ward, ICB or TTWA — that joins straight to boundaries
 ([`load_geodata`](geo.md)) and statistics ([`load_ons`](ons.md)).
 
 ## Functions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
     - Overview: api/index.md
     - Geographic Data: api/geo.md
     - ONS Data: api/ons.md
+    - Postcodes: api/postcodes.md
     - Data Sources: api/data-sources.md
   - Case Studies:
     - Overview: case-studies/index.md

--- a/src/kindtech/__init__.py
+++ b/src/kindtech/__init__.py
@@ -15,6 +15,12 @@ from kindtech._mapping import (
 )
 from kindtech.geo import geodata_to_properties, load_geodata
 from kindtech.ons import list_tables, load_ons
+from kindtech.postcodes import (
+    lookup_outcodes,
+    lookup_postcodes,
+    outcode_to_geography,
+    postcodes_to_geography,
+)
 
 # Define what's available when using `from kindtech import *`
 __all__ = [
@@ -24,4 +30,8 @@ __all__ = [
     "list_tables",
     "load_geodata",
     "load_ons",
+    "lookup_outcodes",
+    "lookup_postcodes",
+    "outcode_to_geography",
+    "postcodes_to_geography",
 ]

--- a/src/kindtech/_frames.py
+++ b/src/kindtech/_frames.py
@@ -10,7 +10,15 @@ from typing import Any
 
 
 def get_native_namespace() -> Any:
-    """Return the best available DataFrame backend module (polars or pandas)."""
+    """Return the DataFrame backend module to build native frames with.
+
+    KindTech depends only on ``narwhals`` (plus ``requests``), not on pandas or
+    polars — users bring whichever they already use. This detects what's
+    installed rather than forcing one: polars is tried first (faster, and the
+    narwhals-native backend) and pandas second. The order only matters when
+    *both* are installed; if neither is, a clear ImportError tells the user to
+    install one.
+    """
     try:
         import polars
 

--- a/src/kindtech/_frames.py
+++ b/src/kindtech/_frames.py
@@ -1,0 +1,48 @@
+"""Shared helpers for building native DataFrames (pandas or polars).
+
+KindTech is backend-agnostic (Bring Your Own DataFrame): it returns whatever
+backend the user has installed. These helpers centralise backend detection and
+construction so the ``ons`` and ``postcodes`` modules don't each reimplement it.
+"""
+
+from io import StringIO
+from typing import Any
+
+
+def get_native_namespace() -> Any:
+    """Return the best available DataFrame backend module (polars or pandas)."""
+    try:
+        import polars
+
+        return polars
+    except ImportError:
+        pass
+    try:
+        import pandas
+
+        return pandas
+    except ImportError:
+        pass
+    msg = (
+        "No DataFrame backend found. "
+        "Install pandas or polars: `uv add pandas` or `uv add polars`"
+    )
+    raise ImportError(msg)
+
+
+def dicts_to_frame(rows: list[dict]) -> Any:
+    """Build a native DataFrame from a list of row dicts.
+
+    Column order follows the keys of the first row. Missing keys in later rows
+    are filled with ``None``.
+    """
+    native_ns = get_native_namespace()
+    if not rows:
+        return native_ns.DataFrame()
+    columns = {key: [row.get(key) for row in rows] for key in rows[0]}
+    return native_ns.DataFrame(columns)
+
+
+def csv_to_frame(text: str) -> Any:
+    """Parse CSV text into a native DataFrame using the available backend."""
+    return get_native_namespace().read_csv(StringIO(text))

--- a/src/kindtech/ons/api.py
+++ b/src/kindtech/ons/api.py
@@ -27,12 +27,12 @@ Examples:
 """
 
 import logging
-from io import StringIO
 from typing import Any
 
 import narwhals.stable.v2 as nw
 import requests
 
+from kindtech._frames import csv_to_frame, dicts_to_frame
 from kindtech._mapping import extract_code, resolve_dataset_id, resolve_nomis_geography
 
 from . import _catalog
@@ -42,44 +42,14 @@ NOMIS_BASE_URL = "https://www.nomisweb.co.uk/api/v01"
 logger = logging.getLogger(__name__)
 
 
-def _get_native_namespace() -> Any:
-    """Detect the best available DataFrame backend."""
-    try:
-        import polars
-
-        return polars
-    except ImportError:
-        pass
-    try:
-        import pandas
-
-        return pandas
-    except ImportError:
-        pass
-    msg = (
-        "No DataFrame backend found. "
-        "Install pandas or polars: `uv add pandas` "
-        "or `uv add polars`"
-    )
-    raise ImportError(msg)
-
-
 def _csv_text_to_frame(text: str) -> nw.DataFrame:
     """Parse CSV text into a narwhals DataFrame using the available backend."""
-    native_ns = _get_native_namespace()
-    native_df = native_ns.read_csv(StringIO(text))
-    return nw.from_native(native_df, eager_only=True)
+    return nw.from_native(csv_to_frame(text), eager_only=True)
 
 
 def _dicts_to_frame(data: list[dict]) -> nw.DataFrame:
     """Convert a list of dicts to a narwhals DataFrame."""
-    if not data:
-        return nw.from_native(_get_native_namespace().DataFrame(), eager_only=True)
-
-    columns = {key: [row[key] for row in data] for key in data[0]}
-    native_ns = _get_native_namespace()
-    native_df = native_ns.DataFrame(columns)
-    return nw.from_native(native_df, eager_only=True)
+    return nw.from_native(dicts_to_frame(data), eager_only=True)
 
 
 def _extract_year_from_time(time_value: Any) -> int | None:

--- a/src/kindtech/postcodes/__init__.py
+++ b/src/kindtech/postcodes/__init__.py
@@ -2,7 +2,7 @@
 KindTech Postcodes Package
 
 Turns UK postcodes and outcodes into ONS geography codes via postcodes.io, so
-client address data joins directly to KindTech boundaries and statistics.
+address data joins directly to KindTech boundaries and statistics.
 """
 
 from .api import (

--- a/src/kindtech/postcodes/__init__.py
+++ b/src/kindtech/postcodes/__init__.py
@@ -1,0 +1,20 @@
+"""
+KindTech Postcodes Package
+
+Turns UK postcodes and outcodes into ONS geography codes via postcodes.io, so
+client address data joins directly to KindTech boundaries and statistics.
+"""
+
+from .api import (
+    lookup_outcodes,
+    lookup_postcodes,
+    outcode_to_geography,
+    postcodes_to_geography,
+)
+
+__all__ = [
+    "lookup_outcodes",
+    "lookup_postcodes",
+    "outcode_to_geography",
+    "postcodes_to_geography",
+]

--- a/src/kindtech/postcodes/api.py
+++ b/src/kindtech/postcodes/api.py
@@ -10,13 +10,13 @@ needed.
 
 The returned ``geography_code`` column aligns with
 :func:`kindtech.geo.api.geodata_to_properties` and :func:`kindtech.ons.load_ons`,
-so a client postcode list joins directly to boundaries and statistics:
+so any list of postcodes joins directly to boundaries and statistics:
 
     >>> from kindtech import postcodes_to_geography, load_geodata, load_ons
     >>> import pandas as pd
     >>>
-    >>> clients = postcodes_to_geography(["SE13 7HX", "SE6 4RU"], "LSOA")
-    >>> per_lsoa = clients.groupby("geography_code").size()  # clients per LSOA
+    >>> located = postcodes_to_geography(["SE13 7HX", "SE6 4RU"], "LSOA")
+    >>> per_lsoa = located.groupby("geography_code").size()  # rows per LSOA
 """
 
 import logging
@@ -247,7 +247,7 @@ def outcode_to_geography(
     .. warning::
         An outcode covers many LSOAs/wards. This returns the geography
         *containing the outcode's geometric centroid* — a rough stand-in, not
-        an exact mapping. For per-area analysis (e.g. referrals per capita by
+        an exact mapping. For per-area analysis (e.g. counts per capita by
         LSOA) prefer full postcodes via :func:`postcodes_to_geography`, or a
         population-weighted split across the outcode's constituent areas.
 

--- a/src/kindtech/postcodes/api.py
+++ b/src/kindtech/postcodes/api.py
@@ -37,8 +37,8 @@ logger = logging.getLogger(__name__)
 
 # Which key in the postcodes.io ``codes`` dict holds the code for each
 # KindTech geography type, paired with the row column its name lands in.
-# 2021 census geographies are preferred to match Census 2021 and current
-# boundary data.
+# Where a level has both vintages, the 2021 geography is chosen so codes
+# align with the rest of KindTech (boundaries and statistics).
 _LEVEL_FIELDS: dict[str, tuple[str, str | None]] = {
     "LSOA": ("lsoa_code", "lsoa_name"),
     "MSOA": ("msoa_code", "msoa_name"),

--- a/src/kindtech/postcodes/api.py
+++ b/src/kindtech/postcodes/api.py
@@ -1,0 +1,317 @@
+"""
+KindTech Postcodes API
+
+Wraps `postcodes.io <https://postcodes.io/>`_ to turn UK postcodes (and
+postcode outcodes) into the ONS geography codes the rest of KindTech joins on.
+
+postcodes.io is built on the ONS Postcode Directory, Ordnance Survey Open Names
+and the Scottish Postcode Directory (all Open Government Licence). No API key is
+needed.
+
+The returned ``geography_code`` column aligns with
+:func:`kindtech.geo.api.geodata_to_properties` and :func:`kindtech.ons.load_ons`,
+so a client postcode list joins directly to boundaries and statistics:
+
+    >>> from kindtech import postcodes_to_geography, load_geodata, load_ons
+    >>> import pandas as pd
+    >>>
+    >>> clients = postcodes_to_geography(["SE13 7HX", "SE6 4RU"], "LSOA")
+    >>> per_lsoa = clients.groupby("geography_code").size()  # clients per LSOA
+"""
+
+import logging
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+import requests
+
+from kindtech._frames import dicts_to_frame
+from kindtech._mapping import extract_code
+
+POSTCODES_BASE_URL = "https://api.postcodes.io"
+
+# postcodes.io caps bulk lookups at 100 postcodes per request.
+BULK_BATCH_SIZE = 100
+
+logger = logging.getLogger(__name__)
+
+# Which key in the postcodes.io ``codes`` dict holds the code for each
+# KindTech geography type, paired with the row column its name lands in.
+# 2021 census geographies are preferred to match Census 2021 and current
+# boundary data.
+_LEVEL_FIELDS: dict[str, tuple[str, str | None]] = {
+    "LSOA": ("lsoa_code", "lsoa_name"),
+    "MSOA": ("msoa_code", "msoa_name"),
+    "OA": ("oa_code", None),
+    "LAD": ("lad_code", "lad_name"),
+    "WD": ("ward_code", None),
+    "ICB": ("icb_code", None),
+    "TTWA": ("ttwa_code", None),
+}
+
+_NULL_ROW: dict[str, Any] = {
+    "lsoa_code": None,
+    "lsoa_name": None,
+    "msoa_code": None,
+    "msoa_name": None,
+    "oa_code": None,
+    "lad_code": None,
+    "lad_name": None,
+    "ward_code": None,
+    "icb_code": None,
+    "ttwa_code": None,
+    "latitude": None,
+    "longitude": None,
+}
+
+
+def _chunks(items: list[str], size: int) -> Iterator[list[str]]:
+    """Yield successive ``size``-length chunks of ``items``."""
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+def _as_list(value: str | Iterable[str]) -> list[str]:
+    """Normalise a single string or an iterable of strings to a list."""
+    if isinstance(value, str):
+        return [value]
+    return list(value)
+
+
+def _row_from_result(query: str, result: dict | None) -> dict[str, Any]:
+    """Shape a postcodes.io lookup result into a flat row.
+
+    ``result`` is ``None`` for an unrecognised postcode/location.
+    """
+    if not result:
+        return {"postcode": query, "valid": False, **_NULL_ROW}
+    codes = result.get("codes", {})
+    return {
+        "postcode": result.get("postcode", query),
+        "valid": True,
+        "lsoa_code": codes.get("lsoa21") or codes.get("lsoa"),
+        "lsoa_name": result.get("lsoa"),
+        "msoa_code": codes.get("msoa21") or codes.get("msoa"),
+        "msoa_name": result.get("msoa"),
+        "oa_code": codes.get("oa21"),
+        "lad_code": codes.get("admin_district"),
+        "lad_name": result.get("admin_district"),
+        "ward_code": codes.get("admin_ward"),
+        "icb_code": codes.get("icb"),
+        "ttwa_code": codes.get("ttwa"),
+        "latitude": result.get("latitude"),
+        "longitude": result.get("longitude"),
+    }
+
+
+def _lookup_rows(postcodes: list[str], base_url: str) -> list[dict[str, Any]]:
+    """Bulk-look up postcodes, preserving input order, one row each."""
+    rows: list[dict[str, Any]] = []
+    for batch in _chunks(postcodes, BULK_BATCH_SIZE):
+        response = _post(f"{base_url}/postcodes", {"postcodes": batch})
+        for entry in response["result"]:
+            rows.append(_row_from_result(entry["query"], entry.get("result")))
+    return rows
+
+
+def _resolve_level(geography_type: Any) -> tuple[str, str | None]:
+    """Validate a geography type and return its (code_col, name_col)."""
+    geo = extract_code(geography_type)
+    if geo not in _LEVEL_FIELDS:
+        supported = ", ".join(sorted(_LEVEL_FIELDS))
+        msg = (
+            f"Unsupported geography_type {geo!r}. "
+            f"Postcode lookup supports: {supported}."
+        )
+        raise ValueError(msg)
+    return _LEVEL_FIELDS[geo]
+
+
+def lookup_postcodes(
+    postcodes: str | Iterable[str],
+    base_url: str = POSTCODES_BASE_URL,
+) -> Any:
+    """Look up one or many UK postcodes.
+
+    Args:
+        postcodes: A single postcode or an iterable of postcodes. Whitespace
+            and case are handled by postcodes.io.
+        base_url: postcodes.io base URL.
+
+    Returns:
+        DataFrame (pandas or polars) with one row per input postcode, in input
+        order. Columns: ``postcode``, ``valid`` (False for unrecognised
+        postcodes), ``lsoa_code``/``lsoa_name``, ``msoa_code``/``msoa_name``,
+        ``oa_code``, ``lad_code``/``lad_name``, ``ward_code``, ``icb_code``,
+        ``ttwa_code``, ``latitude``, ``longitude``.
+
+    Raises:
+        ImportError: If neither pandas nor polars is installed.
+    """
+    rows = _lookup_rows(_as_list(postcodes), base_url)
+    return dicts_to_frame(rows)
+
+
+def postcodes_to_geography(
+    postcodes: str | Iterable[str],
+    geography_type: Any = "LSOA",
+    base_url: str = POSTCODES_BASE_URL,
+) -> Any:
+    """Map postcodes to a single geography level, ready to join.
+
+    Args:
+        postcodes: A single postcode or an iterable of postcodes.
+        geography_type: One of ``LSOA``, ``MSOA``, ``OA``, ``LAD``, ``WD``,
+            ``ICB``, ``TTWA`` (string or :class:`~kindtech.geo.GeographyType`).
+        base_url: postcodes.io base URL.
+
+    Returns:
+        DataFrame with columns ``postcode``, ``geography_code``,
+        ``geography_name``. ``geography_code`` aligns with
+        :func:`~kindtech.geo.geodata_to_properties` and
+        :func:`~kindtech.ons.load_ons`, so the result joins straight to
+        boundaries and statistics. ``geography_code`` is ``None`` for
+        unrecognised postcodes.
+
+    Raises:
+        ValueError: If ``geography_type`` is not supported.
+        ImportError: If neither pandas nor polars is installed.
+    """
+    code_col, name_col = _resolve_level(geography_type)
+    rows = _lookup_rows(_as_list(postcodes), base_url)
+    tidy = [
+        {
+            "postcode": row["postcode"],
+            "geography_code": row[code_col],
+            "geography_name": row[name_col] if name_col else None,
+        }
+        for row in rows
+    ]
+    return dicts_to_frame(tidy)
+
+
+def lookup_outcodes(
+    outcodes: str | Iterable[str],
+    base_url: str = POSTCODES_BASE_URL,
+) -> Any:
+    """Look up postcode outcodes (the prefix before the space, e.g. ``SE13``).
+
+    An outcode spans many areas, so postcodes.io returns the *list* of Local
+    Authorities it touches plus the outcode's geometric centroid.
+
+    Args:
+        outcodes: A single outcode or an iterable of outcodes.
+        base_url: postcodes.io base URL.
+
+    Returns:
+        DataFrame with one row per outcode. Columns: ``outcode``, ``valid``,
+        ``admin_districts`` (comma-separated LAD names the outcode spans),
+        ``latitude``, ``longitude`` (centroid).
+
+    Raises:
+        ImportError: If neither pandas nor polars is installed.
+    """
+    rows: list[dict[str, Any]] = []
+    for outcode in _as_list(outcodes):
+        result = _get(f"{base_url}/outcodes/{outcode}")
+        if not result:
+            rows.append(
+                {
+                    "outcode": outcode,
+                    "valid": False,
+                    "admin_districts": None,
+                    "latitude": None,
+                    "longitude": None,
+                }
+            )
+            continue
+        rows.append(
+            {
+                "outcode": result.get("outcode", outcode),
+                "valid": True,
+                "admin_districts": ", ".join(result.get("admin_district", [])),
+                "latitude": result.get("latitude"),
+                "longitude": result.get("longitude"),
+            }
+        )
+    return dicts_to_frame(rows)
+
+
+def outcode_to_geography(
+    outcodes: str | Iterable[str],
+    geography_type: Any = "LSOA",
+    base_url: str = POSTCODES_BASE_URL,
+) -> Any:
+    """Approximate an outcode to a single geography via its centroid.
+
+    .. warning::
+        An outcode covers many LSOAs/wards. This returns the geography
+        *containing the outcode's geometric centroid* — a rough stand-in, not
+        an exact mapping. For per-area analysis (e.g. referrals per capita by
+        LSOA) prefer full postcodes via :func:`postcodes_to_geography`, or a
+        population-weighted split across the outcode's constituent areas.
+
+    Args:
+        outcodes: A single outcode or an iterable of outcodes.
+        geography_type: Target level (see :func:`postcodes_to_geography`).
+        base_url: postcodes.io base URL.
+
+    Returns:
+        DataFrame with columns ``outcode``, ``geography_code``,
+        ``geography_name`` (centroid-based; ``None`` for unrecognised outcodes).
+
+    Raises:
+        ValueError: If ``geography_type`` is not supported.
+        ImportError: If neither pandas nor polars is installed.
+    """
+    code_col, name_col = _resolve_level(geography_type)
+    rows: list[dict[str, Any]] = []
+    for outcode in _as_list(outcodes):
+        centroid = _get(f"{base_url}/outcodes/{outcode}")
+        nearest = None
+        if centroid and centroid.get("longitude") is not None:
+            results = _get_list(
+                f"{base_url}/postcodes",
+                params={
+                    "lon": centroid["longitude"],
+                    "lat": centroid["latitude"],
+                },
+            )
+            nearest = results[0] if results else None
+        mapped = _row_from_result(outcode, nearest)
+        rows.append(
+            {
+                "outcode": outcode,
+                "geography_code": mapped[code_col],
+                "geography_name": mapped[name_col] if name_col else None,
+            }
+        )
+    return dicts_to_frame(rows)
+
+
+def _post(url: str, payload: dict) -> dict:
+    """POST JSON and return the parsed body."""
+    logger.info("POST %s", url)
+    response = requests.post(url, json=payload, timeout=60)
+    response.raise_for_status()
+    return response.json()
+
+
+def _get(url: str, params: dict | None = None) -> dict | None:
+    """GET a single-object endpoint, returning its ``result`` (or None on 404)."""
+    logger.info("GET %s", url)
+    response = requests.get(url, params=params, timeout=60)
+    if response.status_code == 404:
+        return None
+    response.raise_for_status()
+    return response.json().get("result")
+
+
+def _get_list(url: str, params: dict | None = None) -> list | None:
+    """GET a list endpoint, returning its ``result`` list (or None)."""
+    logger.info("GET %s", url)
+    response = requests.get(url, params=params, timeout=60)
+    if response.status_code == 404:
+        return None
+    response.raise_for_status()
+    return response.json().get("result")

--- a/tests/test_postcodes_api.py
+++ b/tests/test_postcodes_api.py
@@ -1,0 +1,211 @@
+"""
+Unit tests for the KindTech Postcodes API.
+
+External web requests to postcodes.io are mocked so tests are isolated and
+repeatable.
+"""
+
+import unittest.mock as mock
+
+import pandas as pd
+import pytest
+
+from kindtech.postcodes import (
+    lookup_outcodes,
+    lookup_postcodes,
+    outcode_to_geography,
+    postcodes_to_geography,
+)
+
+
+def _codes(**overrides):
+    """A representative postcodes.io ``codes`` dict."""
+    base = {
+        "admin_district": "E09000023",
+        "admin_ward": "E05013727",
+        "lsoa21": "E01034394",
+        "msoa21": "E02007008",
+        "oa21": "E00182613",
+        "icb": "E54000030",
+        "ttwa": "E30000234",
+    }
+    base.update(overrides)
+    return base
+
+
+def _bulk_result(query, *, lsoa="E01034394", district="Lewisham"):
+    """One entry of a bulk /postcodes response."""
+    return {
+        "query": query,
+        "result": {
+            "postcode": query,
+            "lsoa": "Lewisham 040C",
+            "msoa": "Lewisham 040",
+            "admin_district": district,
+            "latitude": 51.45,
+            "longitude": -0.0,
+            "codes": _codes(lsoa21=lsoa),
+        },
+    }
+
+
+def _mock_post(payload):
+    """Build a mock response object for a bulk POST."""
+    resp = mock.MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = mock.MagicMock()
+    resp.json.return_value = payload
+    return resp
+
+
+@mock.patch("kindtech.postcodes.api.requests.post")
+def test_lookup_postcodes_basic(mock_post):
+    mock_post.return_value = _mock_post(
+        {"result": [_bulk_result("SE13 7HX"), _bulk_result("M1 1AE")]}
+    )
+
+    df = lookup_postcodes(["SE13 7HX", "M1 1AE"])
+
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 2
+    assert list(df["postcode"]) == ["SE13 7HX", "M1 1AE"]
+    assert df.loc[0, "lsoa_code"] == "E01034394"
+    assert df.loc[0, "lad_code"] == "E09000023"
+    assert bool(df["valid"].all())
+    mock_post.assert_called_once()
+
+
+@mock.patch("kindtech.postcodes.api.requests.post")
+def test_lookup_postcodes_single_string(mock_post):
+    mock_post.return_value = _mock_post({"result": [_bulk_result("SE13 7HX")]})
+
+    df = lookup_postcodes("SE13 7HX")
+
+    assert len(df) == 1
+    # A single string must be sent as a one-element list.
+    sent = mock_post.call_args.kwargs["json"]["postcodes"]
+    assert sent == ["SE13 7HX"]
+
+
+@mock.patch("kindtech.postcodes.api.requests.post")
+def test_invalid_postcode_flagged_not_dropped(mock_post):
+    mock_post.return_value = _mock_post(
+        {"result": [_bulk_result("SE13 7HX"), {"query": "NOPE", "result": None}]}
+    )
+
+    df = lookup_postcodes(["SE13 7HX", "NOPE"])
+
+    assert len(df) == 2  # invalid row preserved, not dropped
+    invalid = df[df["postcode"] == "NOPE"].iloc[0]
+    assert not bool(invalid["valid"])
+    assert pd.isna(invalid["lsoa_code"])
+
+
+@mock.patch("kindtech.postcodes.api.requests.post")
+def test_bulk_batched_over_100(mock_post):
+    # 250 postcodes -> 3 batches (100, 100, 50).
+    def side_effect(url, json, timeout):
+        return _mock_post({"result": [_bulk_result(p) for p in json["postcodes"]]})
+
+    mock_post.side_effect = side_effect
+    postcodes = [f"AA{i}" for i in range(250)]
+
+    df = lookup_postcodes(postcodes)
+
+    assert len(df) == 250
+    assert mock_post.call_count == 3
+    sizes = [len(c.kwargs["json"]["postcodes"]) for c in mock_post.call_args_list]
+    assert sizes == [100, 100, 50]
+
+
+@mock.patch("kindtech.postcodes.api.requests.post")
+def test_postcodes_to_geography_lsoa(mock_post):
+    mock_post.return_value = _mock_post(
+        {"result": [_bulk_result("SE13 7HX", lsoa="E01034394")]}
+    )
+
+    df = postcodes_to_geography(["SE13 7HX"], "LSOA")
+
+    assert list(df.columns) == ["postcode", "geography_code", "geography_name"]
+    assert df.loc[0, "geography_code"] == "E01034394"
+    assert df.loc[0, "geography_name"] == "Lewisham 040C"
+
+
+@mock.patch("kindtech.postcodes.api.requests.post")
+def test_postcodes_to_geography_lad(mock_post):
+    mock_post.return_value = _mock_post({"result": [_bulk_result("SE13 7HX")]})
+
+    df = postcodes_to_geography("SE13 7HX", "LAD")
+
+    assert df.loc[0, "geography_code"] == "E09000023"
+    assert df.loc[0, "geography_name"] == "Lewisham"
+
+
+def test_postcodes_to_geography_rejects_unsupported_level():
+    with pytest.raises(ValueError, match="Unsupported geography_type"):
+        postcodes_to_geography(["SE13 7HX"], "CTRY")
+
+
+@mock.patch("kindtech.postcodes.api.requests.get")
+def test_lookup_outcodes_one_to_many(mock_get):
+    resp = mock.MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = mock.MagicMock()
+    resp.json.return_value = {
+        "result": {
+            "outcode": "SE13",
+            "admin_district": ["Greenwich", "Lewisham"],
+            "latitude": 51.46,
+            "longitude": -0.01,
+        }
+    }
+    mock_get.return_value = resp
+
+    df = lookup_outcodes("SE13")
+
+    assert df.loc[0, "outcode"] == "SE13"
+    assert df.loc[0, "admin_districts"] == "Greenwich, Lewisham"
+    assert bool(df.loc[0, "valid"])
+
+
+@mock.patch("kindtech.postcodes.api.requests.get")
+def test_lookup_outcodes_invalid(mock_get):
+    resp = mock.MagicMock()
+    resp.status_code = 404
+    mock_get.return_value = resp
+
+    df = lookup_outcodes("ZZ99")
+
+    assert not bool(df.loc[0, "valid"])
+    assert df.loc[0, "admin_districts"] is None
+
+
+@mock.patch("kindtech.postcodes.api.requests.get")
+def test_outcode_to_geography_centroid(mock_get):
+    centroid_resp = mock.MagicMock()
+    centroid_resp.status_code = 200
+    centroid_resp.raise_for_status = mock.MagicMock()
+    centroid_resp.json.return_value = {
+        "result": {"outcode": "SE13", "latitude": 51.46, "longitude": -0.01}
+    }
+    nearest_resp = mock.MagicMock()
+    nearest_resp.status_code = 200
+    nearest_resp.raise_for_status = mock.MagicMock()
+    nearest_resp.json.return_value = {
+        "result": [
+            {
+                "postcode": "SE13 6BY",
+                "lsoa": "Lewisham 041B",
+                "admin_district": "Lewisham",
+                "codes": _codes(lsoa21="E01033327"),
+            }
+        ]
+    }
+    # First GET = outcode centroid, second GET = reverse geocode.
+    mock_get.side_effect = [centroid_resp, nearest_resp]
+
+    df = outcode_to_geography("SE13", "LSOA")
+
+    assert df.loc[0, "outcode"] == "SE13"
+    assert df.loc[0, "geography_code"] == "E01033327"
+    assert df.loc[0, "geography_name"] == "Lewisham 041B"


### PR DESCRIPTION
## What
Introduces `kindtech.postcodes`, turning UK postcodes and outcodes into the ONS geography codes the geo and ons modules already join on.

## Why
This is the missing link for charity client data: a list of client postcodes becomes a `geography_code` column that merges straight to boundaries and statistics. It unblocks the CAL and Sobus case studies.

## How
A thin runtime wrapper over [postcodes.io](https://postcodes.io/) (built on the ONS Postcode Directory, OS Open Names and the Scottish Postcode Directory — all OGL; no API key). The bulk products are too large to ship, so wrapping the API keeps kindtech a thin client with no bundled data.

- `postcodes_to_geography(postcodes, geography_type)` — tidy `postcode → geography_code/geography_name`, ready to join (LSOA/MSOA/OA/LAD/WD/ICB/TTWA).
- `lookup_postcodes(postcodes)` — full per-postcode row with every level + lat/long; invalid postcodes are flagged, not dropped.
- `lookup_outcodes(outcodes)` / `outcode_to_geography(...)` — outcode centroid and one-to-many LADs, plus a centroid-based approximation (with caveats) for data tagged only by postcode prefix.

Requests are batched at the 100-postcode limit and preserve input order. Shared DataFrame construction is factored into `kindtech._frames` and reused by the ons module. Includes mocked-HTTP unit tests and docs (API page, Data Sources section, nav).