### PR TITLE
Publish docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+# Allow the GITHUB_TOKEN to deploy to GitHub Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One concurrent deployment; don't cancel an in-progress run.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build site
+        run: uv run --group dev mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: KindTech
+site_url: https://kindtechuk.github.io/kindtech/
 
 # Repository information
 repo_name: KindTechUK/kindtech


### PR DESCRIPTION
## What this adds

A GitHub Actions workflow (`.github/workflows/docs.yml`) that builds the mkdocs site with `uv` and publishes it to **GitHub Pages** on every push to `main` that touches `docs/` or `mkdocs.yml`. Also sets `site_url` so canonical links and the sitemap resolve.

This makes the case-study write-ups — including the reproduced charts — viewable on the web instead of only when building the docs locally.

## One-time repo setting required

After merge, enable Pages with the Actions source:
**Settings → Pages → Build and deployment → Source = GitHub Actions.**

(The workflow already requests the right `pages: write` / `id-token: write` permissions; this toggle just tells GitHub to accept Actions-based deployments. The first deploy runs automatically on the next push to `main`, or via the workflow's `workflow_dispatch` trigger.)

## Notes

- Build uses `uv run --group dev mkdocs build --strict` — same command verified locally; `--strict` fails the build on broken links/nav.
- Independent of the case-study PRs; merging this first means each case study renders as soon as it lands.