### PR TITLE
Docs polish: orange theme, prominent examples, list fixes

### DIFF
--- a/docs/case-studies/cal-vulnerable-client.md
+++ b/docs/case-studies/cal-vulnerable-client.md
@@ -9,6 +9,7 @@
 Citizens Advice Lewisham (CAL) needed to identify 'vulnerability hotspots' - areas with high need but limited access to resources - to optimize service delivery.
 
 **Key objectives:**
+
 - Map vulnerability hotspots in Lewisham
 - Optimize service delivery based on geographic need
 - Validate service targeting effectiveness
@@ -35,11 +36,13 @@ Citizens Advice Lewisham (CAL) needed to identify 'vulnerability hotspots' - are
 ### Data Requirements
 
 **Internal Dataset:**
+
 - Individual client records with vulnerability factor scores
 - Postcode data for geographic mapping
 - Goal: Map postcodes to LSOAs to calculate clients per capita
 
 **External Datasets:**
+
 - **Index of Multiple Deprivation (IMD)**: LSOA-level deprivation scores for overlay analysis
 - **Census Data**: Population figures for per-capita calculations
 - **LSOA Boundaries**: Geographic polygons for spatial analysis and mapping

--- a/docs/case-studies/material-focus-recycling.md
+++ b/docs/case-studies/material-focus-recycling.md
@@ -9,6 +9,7 @@
 Material Focus needed to gather evidence to demonstrate to stakeholders what interventions would make the greatest difference in increasing electrical item recycling rates across the UK.
 
 **Key Research Questions**:
+
 - Where in the UK could Material Focus achieve the greatest impact if small electricals were recycled through major supermarkets?
 - Do factors like proximity to collection points influence recycling rates in different areas?
 - What barriers prevent individuals from recycling electrical goods?
@@ -18,11 +19,13 @@ Material Focus needed to gather evidence to demonstrate to stakeholders what int
 ## Dataset Involved
 
 **Internal Data**:
+
 - Existing recycling rates for electronic goods and general recycling
 - Location of current recycling points across the UK
 - Travel times from residential areas to nearest recycling facilities
 
 **External Data**:
+
 - Population density by geographic area
 - Car ownership rates
 - Housing types and demographics
@@ -35,6 +38,7 @@ Material Focus needed to gather evidence to demonstrate to stakeholders what int
 **Key Finding**: The visualization revealed that a significant proportion of people across England have access to recycling points within 12 minutes of travel time, indicating good baseline infrastructure coverage.
 
 **Behavioral Analysis**: Material Focus was particularly interested in understanding what factors would influence new individuals to start recycling—not just optimizing for people already engaged in recycling. The analysis examined:
+
 - Travel distance to recycling facilities
 - Population density compared to recycling participation rates
 - Availability of kerbside collection services

--- a/docs/case-studies/smart-works-woman-unemployment.md
+++ b/docs/case-studies/smart-works-woman-unemployment.md
@@ -11,12 +11,14 @@ Smart Works needed to identify gaps in their service provision and optimize thei
 **Key Challenge**: With over 632,500 unemployed women in their operating areas, Smart Works was not reaching all potential beneficiaries and struggled to identify service gaps.
 
 **Key objectives:**
+
 - Map the distribution of Smart Works clients across Local Authorities
 - Identify areas with high unemployment but low client numbers
 - Analyze demographic disparities between clients and national unemployment data
 - Optimize outreach strategy and inform future center locations
 
 **Research Questions:**
+
 - Which Local Authorities have high unemployment rates but low Smart Works client numbers?
 - Are there specific demographic groups (age, ethnicity) that Smart Works is under-serving?
 - Where should Smart Works focus their efforts or consider opening new centers?
@@ -25,6 +27,7 @@ Smart Works needed to identify gaps in their service provision and optimize thei
 ## Dataset Involved
 
 **Primary Data Sources**:
+
 - **Census 2021**: Comprehensive demographic and employment data by Local Authority
 - **Annual Population Survey**: Current unemployment statistics and trends
 - **Smart Works Internal Data**: Client records with geographic and demographic information
@@ -32,6 +35,7 @@ Smart Works needed to identify gaps in their service provision and optimize thei
 **Data Integration**: Publicly available 'open data' from Census 2021 and Annual Population Survey was mapped to show women's unemployment rates by Local Authority and compared to Smart Works client distribution.
 
 **Analysis Scope**:
+
 - Geographic comparison of unemployment rates vs. client numbers
 - Demographic analysis comparing Smart Works clients to overall unemployed women population
 
@@ -52,11 +56,13 @@ Smart Works needed to identify gaps in their service provision and optimize thei
 ### Data Requirements
 
 **Internal Dataset**: Smart Works client records with:
+
 - Geographic location (Local Authority)
 - Demographic information (age, ethnicity)
 - Service usage patterns
 
 **External Datasets**:
+
 - **Census 2021**: Local Authority-level unemployment and demographic data
 - **Annual Population Survey**: Current unemployment statistics
 - **Local Authority Boundaries**: Geographic polygons for spatial analysis and mapping

--- a/docs/case-studies/sobus-bame-analysis.md
+++ b/docs/case-studies/sobus-bame-analysis.md
@@ -11,6 +11,7 @@ Sobus identified ongoing concerns about the disproportionate numbers of BAME (Bl
 **Key Challenge**: There was a lack of comprehensive local data mapping the BAME mental health landscape, making it difficult to understand the scope and nature of service gaps.
 
 **Research Questions**:
+
 - Was there a disproportionate representation of BAME people diagnosed and under the care of Mental Health Services?
 - What was the current service provision for the BAME community suffering from mental health issues?
 - How could data-driven insights inform more equitable mental health service delivery?

--- a/docs/case-studies/starlight-children-mapping.md
+++ b/docs/case-studies/starlight-children-mapping.md
@@ -9,12 +9,14 @@
 Starlight Children's Foundation needed to understand where there is overlap between their services, hospital play provision, and donors to make strategic decisions about service provision and fundraising efforts.
 
 **Key objectives:**
+
 - Map the distribution of Starlight services across the UK
 - Identify gaps in play provision and service coverage
 - Analyze disparities between different ethnicities and demographics
 - Optimize resource allocation based on demonstrated need
 
 **Research Questions:**
+
 - Where are the gaps between Starlight's services and areas of greatest need?
 - How does play provision vary across different regions and demographics?
 - What factors influence the distribution of hospital play services?
@@ -25,6 +27,7 @@ Starlight Children's Foundation needed to understand where there is overlap betw
 **Primary Data Collection**: Much of the data had to be collected through freedom of information (FOI) requests from 140 hospital trusts and health boards across the UK.
 
 **Data Types Collected:**
+
 - Number of child admissions by hospital
 - Level of play provision and specialist staff
 - Play budgets and resource allocation
@@ -51,6 +54,7 @@ Starlight Children's Foundation needed to understand where there is overlap betw
 ### Data Requirements
 
 **Synthetic Data Generation**: Create realistic datasets representing:
+
 - Play provision levels across clinical commissioning groups (CCGs)
 - Hospital admission rates for children
 - Geographic distribution of Starlight services

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,49 @@
+# Examples
+
+Runnable [marimo](https://marimo.io/) notebooks. Open any of them in the molab
+cloud runtime to run it **in your browser** — each fetches live ONS data — or
+run locally with `uv run marimo edit examples/<notebook>.py`.
+
+## Connector basics
+
+<div class="grid cards" markdown>
+
+-   __ONS statistics__
+
+    ---
+
+    Browse and load datasets straight from the NOMIS API.
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/ons_statistics.py)
+
+-   __Geographic boundaries__
+
+    ---
+
+    Explore LAD, LSOA and other UK boundary data interactively.
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/geo_boundaries.py)
+
+-   __Boundaries + statistics__
+
+    ---
+
+    Join geographic shapes with ONS data and map the result.
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/geo_plus_ons.py)
+
+</div>
+
+## Case studies
+
+End-to-end reproductions of [DataKind UK](https://www.datakind.org.uk/) charity
+projects, each chaining several connectors on `geography_code`. See the
+[Case Studies](case-studies/index.md) section for the full write-ups and figures.
+
+| Notebook | Case study |
+|----------|------------|
+| [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/smart_works_unemployment.py) | **Smart Works** — women's unemployment vs service reach (Census 2021 + LAD boundaries) |
+| [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/cal_vulnerable_client.py) | **Citizens Advice Lewisham** — deprivation vs service usage (postcodes + IMD + LSOA boundaries) |
+| [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/sobus_bame_referrals.py) | **Sobus** — BAME mental-health referrals in Hammersmith & Fulham (outcodes + Census ethnicity) |
+| [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/starlight_play_provision.py) | **Starlight** — hospital play provision vs need across ICBs |
+| [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/material_focus_recycling.py) | **Material Focus** — travel time to the nearest recycling point (LAD boundaries + population) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,38 @@
 
 Ergonomic Python access to UK public data. Geographic boundaries from the ONS ArcGIS Geoportal, statistics from the NOMIS API — with universal DataFrame support.
 
+## Try it now — no install
+
+Run a real notebook in your browser. Each one fetches live ONS data through the molab cloud runtime:
+
+<div class="grid cards" markdown>
+
+-   __ONS statistics__
+
+    ---
+
+    Browse and load datasets straight from the NOMIS API.
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/ons_statistics.py)
+
+-   __Geographic boundaries__
+
+    ---
+
+    Explore LAD, LSOA and other UK boundary data interactively.
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/geo_boundaries.py)
+
+-   __Boundaries + statistics__
+
+    ---
+
+    Join geographic shapes with ONS data and map the result.
+
+    [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/geo_plus_ons.py)
+
+</div>
+
 ## Install
 
 ```bash
@@ -62,16 +94,6 @@ You bring the DataFrame library. KindTech brings the data.
 UK public data is powerful but painful to access programmatically. The ONS ArcGIS Geoportal has no developer documentation — just a point-and-click GUI. The REST API endpoint was discovered buried in the source code of an obscure UK government R package. NOMIS is slightly better documented but requires deep knowledge of SDMX query syntax and dataset codes that aren't surfaced anywhere obvious.
 
 Every charity, social enterprise, and researcher working with UK geographic or statistical data ends up reverse-engineering the same APIs independently. KindTech wraps them so you don't have to — two function calls instead of hours of documentation archaeology.
-
-## Interactive examples
-
-Try these notebooks in your browser — no install needed:
-
-| Notebook | Description |
-|----------|-------------|
-| [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/ons_statistics.py) | Browse and load ONS datasets from the NOMIS API |
-| [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/geo_boundaries.py) | Explore UK geographic boundaries |
-| [![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/KindTechUK/kindtech/blob/main/examples/geo_plus_ons.py) | Join boundaries with statistics |
 
 ## Modules
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,14 @@
+/* DataKind-style orange primary. Hex values are approximate — tweak to match
+   the exact brand orange if needed. */
+[data-md-color-primary="custom"] {
+  --md-primary-fg-color: #f58220;
+  --md-primary-fg-color--light: #fba75a;
+  --md-primary-fg-color--dark: #c0651a;
+  --md-primary-bg-color: #ffffff;
+  --md-primary-bg-color--light: rgba(255, 255, 255, 0.7);
+}
+
+[data-md-color-accent="custom"] {
+  --md-accent-fg-color: #c0651a;
+  --md-accent-fg-color--transparent: rgba(245, 130, 32, 0.1);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,23 @@ theme:
 extra_css:
   - stylesheets/extra.css
 
+# Generate /llms.txt + /llms-full.txt and a "copy as Markdown" button per page
+# (LLM-friendly docs). `search` is listed so Material's search stays enabled.
+plugins:
+  - search
+  - llmstxt-md:
+      sections:
+        Home:
+          - index.md
+        Examples:
+          - examples.md
+        Case Studies:
+          - case-studies/*.md
+        User Guide:
+          - api/*.md
+        Blog:
+          - blog/*.md
+
 markdown_extensions:
   - attr_list
   - md_in_html
@@ -56,13 +73,7 @@ markdown_extensions:
 # Navigation structure
 nav:
   - Home: index.md
-  - API Reference:
-    - Overview: api/index.md
-    - Geographic Data: api/geo.md
-    - ONS Data: api/ons.md
-    - Postcodes: api/postcodes.md
-    - Deprivation (IMD): api/imd.md
-    - Data Sources: api/data-sources.md
+  - Examples: examples.md
   - Case Studies:
     - Overview: case-studies/index.md
     - CAL Vulnerable Client Analysis: case-studies/cal-vulnerable-client.md
@@ -70,6 +81,13 @@ nav:
     - Material Focus Recycling: case-studies/material-focus-recycling.md
     - Smart Works Women & Unemployment: case-studies/smart-works-woman-unemployment.md
     - Starlight Children's Foundation: case-studies/starlight-children-mapping.md
+  - User Guide:
+    - Overview: api/index.md
+    - Geographic Data: api/geo.md
+    - ONS Data: api/ons.md
+    - Postcodes: api/postcodes.md
+    - Deprivation (IMD): api/imd.md
+    - Data Sources: api/data-sources.md
   - Blog:
     - blog/index.md
     - Introduction: blog/introduction.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,16 +11,16 @@ theme:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
@@ -28,6 +28,7 @@ theme:
     # Top navigation bar
     - navigation.tabs
     - navigation.tabs.sticky
+    - navigation.sections
     - navigation.top
 
     # Other features
@@ -37,10 +38,16 @@ theme:
     - content.tooltips
     - search.suggest
     - search.highlight
+    - toc.follow
   icon:
     repo: fontawesome/brands/github
 
+extra_css:
+  - stylesheets/extra.css
+
 markdown_extensions:
+  - attr_list
+  - md_in_html
   - admonition
   - pymdownx.details
   - pymdownx.superfences

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ package-dir = {"" = "src"}
 [dependency-groups]
 dev = [
     "mkdocs>=1.6.1",
+    "mkdocs-llmstxt-md>=0.2.0",
     "mkdocs-material>=9.6.14",
     "pandas>=2.0.0",
     "prek>=0.3.5",

--- a/uv.lock
+++ b/uv.lock
@@ -310,6 +310,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "mkdocs" },
+    { name = "mkdocs-llmstxt-md" },
     { name = "mkdocs-material" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -333,6 +334,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs-llmstxt-md", specifier = ">=0.2.0" },
     { name = "mkdocs-material", specifier = ">=9.6.14" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "prek", specifier = ">=0.3.5" },
@@ -455,6 +457,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocs-llmstxt-md"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "ruff" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/86/a899ef021e44e358544b31fd3e34aa566ff876650e7dbede3e677053a492/mkdocs_llmstxt_md-0.2.0.tar.gz", hash = "sha256:c42c86fc316c5e96920b403abfffda7615fe519baca9cdb716e9ff77b703570f", size = 8780, upload-time = "2025-08-01T14:14:10.926Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/96/519526b02a4429262b0e8728765a0bda8a987d1fd4e6ac7655f26ce2a245/mkdocs_llmstxt_md-0.2.0-py3-none-any.whl", hash = "sha256:ce836a6e7bc7f7d0987c8ac0703f04b51f1d7d0096a5700b042161fbbaea5175", size = 7551, upload-time = "2025-08-01T14:14:09.558Z" },
 ]
 
 [[package]]
@@ -1109,27 +1124,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.12.1"
+version = "0.15.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/97/38/796a101608a90494440856ccfb52b1edae90de0b817e76bfade66b12d320/ruff-0.12.1.tar.gz", hash = "sha256:806bbc17f1104fd57451a98a58df35388ee3ab422e029e8f5cf30aa4af2c138c", size = 4413426, upload-time = "2025-06-26T20:34:14.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/bf/3dba52c1d12ab5e78d75bd78ad52fb85a6a1f29cc447c2423037b82bed0d/ruff-0.12.1-py3-none-linux_armv6l.whl", hash = "sha256:6013a46d865111e2edb71ad692fbb8262e6c172587a57c0669332a449384a36b", size = 10305649, upload-time = "2025-06-26T20:33:39.242Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/65/dab1ba90269bc8c81ce1d499a6517e28fe6f87b2119ec449257d0983cceb/ruff-0.12.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b3f75a19e03a4b0757d1412edb7f27cffb0c700365e9d6b60bc1b68d35bc89e0", size = 11120201, upload-time = "2025-06-26T20:33:42.207Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/3e/2d819ffda01defe857fa2dd4cba4d19109713df4034cc36f06bbf582d62a/ruff-0.12.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9a256522893cb7e92bb1e1153283927f842dea2e48619c803243dccc8437b8be", size = 10466769, upload-time = "2025-06-26T20:33:44.102Z" },
-    { url = "https://files.pythonhosted.org/packages/63/37/bde4cf84dbd7821c8de56ec4ccc2816bce8125684f7b9e22fe4ad92364de/ruff-0.12.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:069052605fe74c765a5b4272eb89880e0ff7a31e6c0dbf8767203c1fbd31c7ff", size = 10660902, upload-time = "2025-06-26T20:33:45.98Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/3a/390782a9ed1358c95e78ccc745eed1a9d657a537e5c4c4812fce06c8d1a0/ruff-0.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a684f125a4fec2d5a6501a466be3841113ba6847827be4573fddf8308b83477d", size = 10167002, upload-time = "2025-06-26T20:33:47.81Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/05/f2d4c965009634830e97ffe733201ec59e4addc5b1c0efa035645baa9e5f/ruff-0.12.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdecdef753bf1e95797593007569d8e1697a54fca843d78f6862f7dc279e23bd", size = 11751522, upload-time = "2025-06-26T20:33:49.857Z" },
-    { url = "https://files.pythonhosted.org/packages/35/4e/4bfc519b5fcd462233f82fc20ef8b1e5ecce476c283b355af92c0935d5d9/ruff-0.12.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:70d52a058c0e7b88b602f575d23596e89bd7d8196437a4148381a3f73fcd5010", size = 12520264, upload-time = "2025-06-26T20:33:52.199Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b2/7756a6925da236b3a31f234b4167397c3e5f91edb861028a631546bad719/ruff-0.12.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84d0a69d1e8d716dfeab22d8d5e7c786b73f2106429a933cee51d7b09f861d4e", size = 12133882, upload-time = "2025-06-26T20:33:54.231Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/00/40da9c66d4a4d51291e619be6757fa65c91b92456ff4f01101593f3a1170/ruff-0.12.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6cc32e863adcf9e71690248607ccdf25252eeeab5193768e6873b901fd441fed", size = 11608941, upload-time = "2025-06-26T20:33:56.202Z" },
-    { url = "https://files.pythonhosted.org/packages/91/e7/f898391cc026a77fbe68dfea5940f8213622474cb848eb30215538a2dadf/ruff-0.12.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fd49a4619f90d5afc65cf42e07b6ae98bb454fd5029d03b306bd9e2273d44cc", size = 11602887, upload-time = "2025-06-26T20:33:58.47Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/02/0891872fc6aab8678084f4cf8826f85c5d2d24aa9114092139a38123f94b/ruff-0.12.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ed5af6aaaea20710e77698e2055b9ff9b3494891e1b24d26c07055459bb717e9", size = 10521742, upload-time = "2025-06-26T20:34:00.465Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/98/d6534322c74a7d47b0f33b036b2498ccac99d8d8c40edadb552c038cecf1/ruff-0.12.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:801d626de15e6bf988fbe7ce59b303a914ff9c616d5866f8c79eb5012720ae13", size = 10149909, upload-time = "2025-06-26T20:34:02.603Z" },
-    { url = "https://files.pythonhosted.org/packages/34/5c/9b7ba8c19a31e2b6bd5e31aa1e65b533208a30512f118805371dbbbdf6a9/ruff-0.12.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2be9d32a147f98a1972c1e4df9a6956d612ca5f5578536814372113d09a27a6c", size = 11136005, upload-time = "2025-06-26T20:34:04.723Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/34/9bbefa4d0ff2c000e4e533f591499f6b834346025e11da97f4ded21cb23e/ruff-0.12.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:49b7ce354eed2a322fbaea80168c902de9504e6e174fd501e9447cad0232f9e6", size = 11648579, upload-time = "2025-06-26T20:34:06.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/1c/20cdb593783f8f411839ce749ec9ae9e4298c2b2079b40295c3e6e2089e1/ruff-0.12.1-py3-none-win32.whl", hash = "sha256:d973fa626d4c8267848755bd0414211a456e99e125dcab147f24daa9e991a245", size = 10519495, upload-time = "2025-06-26T20:34:08.718Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/56/7158bd8d3cf16394928f47c637d39a7d532268cd45220bdb6cd622985760/ruff-0.12.1-py3-none-win_amd64.whl", hash = "sha256:9e1123b1c033f77bd2590e4c1fe7e8ea72ef990a85d2484351d408224d603013", size = 11547485, upload-time = "2025-06-26T20:34:11.008Z" },
-    { url = "https://files.pythonhosted.org/packages/91/d0/6902c0d017259439d6fd2fd9393cea1cfe30169940118b007d5e0ea7e954/ruff-0.12.1-py3-none-win_arm64.whl", hash = "sha256:78ad09a022c64c13cc6077707f036bab0fac8cd7088772dcd1e5be21c5002efc", size = 10691209, upload-time = "2025-06-26T20:34:12.928Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Visual + UX polish for the docs site (live at https://kindtechuk.github.io/kindtech/), plus the follow-ups originally deferred to avoid clashing with the connector/case-study stack (now all merged).

### Polish
- **Orange theme** — custom DataKind-style palette (`docs/stylesheets/extra.css`).
- **Interactive examples pop** — molab notebooks as grid cards near the top of the landing page.
- **Fixed run-on lists** — python-markdown needs a blank line before a list; fixed across **all five** case studies (Smart Works, Material Focus, CAL, Sobus, Starlight).
- Enabled `attr_list` + `md_in_html`, `navigation.sections`, `toc.follow`.

### Examples page + nav restructure
- New **Examples** page (`docs/examples.md`) listing every molab notebook (connector basics + the five case studies).
- Nav reordered to **Home → Examples → Case Studies → User Guide → Blog** (the `api/*` reference pages are now grouped under "User Guide").

### LLM-friendly docs (Marimo-style)
- Added the `mkdocs-llmstxt-md` plugin: generates **`/llms.txt`** (sectioned index) and **`/llms-full.txt`** (full content), serves per-page `.md`, and adds a **"copy as Markdown"** button to every page.

## Validated
- `mkdocs build --strict` passes; `llms.txt`/`llms-full.txt`/per-page `.md`/copy button all verified in the built site.
- Adding the plugin re-resolved **ruff 0.12.1 → 0.15.15** in `uv.lock`; `ruff format --check` and `ruff check` pass clean on the new version.