### PR TITLE
CI: per-PR docs previews (pr-preview-action)

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,39 @@
+name: Deploy docs preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "examples/**"
+      - ".github/workflows/docs-preview.yml"
+
+# contents:write to push the preview to gh-pages; pull-requests:write for the sticky comment.
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        if: github.event.action != 'closed'
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build site
+        if: github.event.action != 'closed'
+        run: uv run --group dev mkdocs build --strict
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./site/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,19 +9,17 @@ on:
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
-# Allow the GITHUB_TOKEN to deploy to GitHub Pages.
+# Push the built site to the gh-pages branch (served by GitHub Pages).
+# Explicit contents:write elevates the token even though the org default is read.
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-# One concurrent deployment; don't cancel an in-progress run.
 concurrency:
-  group: pages
+  group: docs-deploy
   cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -33,18 +31,11 @@ jobs:
       - name: Build site
         run: uv run --group dev mkdocs build --strict
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: site
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          folder: site
+          branch: gh-pages
+          # Don't wipe live PR previews when publishing production.
+          clean-exclude: pr-preview/
+          force: false


### PR DESCRIPTION
## What
Adds Cloudflare-Pages-style per-PR docs previews on GitHub Pages via `rossjrw/pr-preview-action`.

- **`docs-preview.yml`** (new): on each PR touching docs, builds the site and deploys it to `gh-pages/pr-preview/pr-<N>/`. A single sticky comment posts the preview URL and updates on every push; the preview is removed when the PR closes.
- **`docs.yml`** (reworked): production now publishes to the **`gh-pages` branch** (`JamesIves/github-pages-deploy-action`) instead of the Actions Pages artifact. `clean-exclude: pr-preview/` ensures a production publish never wipes a live preview.

## Why the rework
GitHub Pages serves one site per repo from a single source, so previews + production must share the `gh-pages` branch.

## Permissions
The org forces the repo default token to read; these workflows declare `contents: write` (+ `pull-requests: write` for the comment) explicitly, which still elevates per-workflow — the same mechanism the current docs deploy already uses for `pages: write`.

## Rollout (after merge)
1. Merge → `docs.yml` publishes production to `gh-pages`.
2. Switch the Pages source from "GitHub Actions" to "Deploy from branch → `gh-pages` / root".
3. Verify the live site; previews then work on every PR.

(This PR will itself post a preview comment; that link only resolves after step 2.)