### PR TITLE
Wire docs into agent discovery channels (llms.txt-first, Context7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ projects, each chaining several connectors on `geography_code`:
 See the [case studies](https://kindtechuk.github.io/kindtech/case-studies/) in
 the docs for the full write-ups and figures.
 
+## For AI agents / LLMs
+
+The docs ship machine-readable indexes:
+[`/llms.txt`](https://kindtechuk.github.io/kindtech/llms.txt) (a curated map) and
+[`/llms-full.txt`](https://kindtechuk.github.io/kindtech/llms-full.txt) (the full
+docs inlined). The library docs are also indexed on
+[Context7](https://context7.com/) for retrieval inside coding agents. See the
+[Recipes for agents](https://kindtechuk.github.io/kindtech/api/recipes/) page for
+copy-paste snippets.
+
 ## Development
 
 See [DEVELOPERS.md](DEVELOPERS.md) for development setup and workflow instructions.

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "KindTech",
+  "description": "Ergonomic Python access to UK public data — ONS/NOMIS statistics and ONS geographic boundaries, with pandas or polars output.",
+  "folders": ["docs"],
+  "excludeFolders": ["site", ".venv", "tests", "src/kindtech.egg-info"],
+  "excludeFiles": [],
+  "rules": [
+    "Install with `uv add kindtech` (never pip).",
+    "The API is flat functions — no classes to instantiate. Call load_geodata(), load_ons(), load_imd(), postcodes_to_geography() directly.",
+    "Everything joins on the `geography_code` column — this is the universal key across the geo, ONS, IMD and postcode connectors.",
+    "Resolve postcodes/outcodes to geography codes first (postcodes_to_geography / outcode_to_geography), then join to boundaries and statistics.",
+    "Bring your own DataFrame backend — narwhals returns pandas or polars depending on what is installed."
+  ]
+}

--- a/context7.json
+++ b/context7.json
@@ -1,15 +1,17 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
   "projectTitle": "KindTech",
-  "description": "Ergonomic Python access to UK public data — ONS/NOMIS statistics and ONS geographic boundaries, with pandas or polars output.",
+  "description": "Ergonomic Python toolkit for UK open-data analysis, mapping and dashboards. Four connectors — ONS/NOMIS statistics (incl. Census 2021), ONS ArcGIS geographic boundaries (GeoJSON), Indices of Multiple Deprivation (England IoD, Wales WIMD, Scotland SIMD, NI NIMDM, plus the mySociety UK composite) and postcode/outcode lookups (postcodes.io) — all keyed on a shared `geography_code` so they join to each other, across geography levels, and to your own first-party data. Output is pandas or polars via narwhals.",
   "folders": ["docs"],
   "excludeFolders": ["site", ".venv", "tests", "src/kindtech.egg-info"],
   "excludeFiles": [],
   "rules": [
     "Install with `uv add kindtech` (never pip).",
-    "The API is flat functions — no classes to instantiate. Call load_geodata(), load_ons(), load_imd(), postcodes_to_geography() directly.",
-    "Everything joins on the `geography_code` column — this is the universal key across the geo, ONS, IMD and postcode connectors.",
-    "Resolve postcodes/outcodes to geography codes first (postcodes_to_geography / outcode_to_geography), then join to boundaries and statistics.",
+    "Four data sources: kindtech.ons (ONS statistics via the NOMIS API, incl. Census 2021), kindtech.geo (UK boundaries as GeoJSON from the ONS ArcGIS Geoportal), kindtech.imd (deprivation for all four UK nations plus the UK-wide composite) and kindtech.postcodes (postcode/outcode → geography via postcodes.io).",
+    "The API is flat functions — no classes to instantiate. Call load_ons(), load_geodata(), load_imd(), postcodes_to_geography() directly.",
+    "`geography_code` is the universal join key — it links every connector to each other AND to your own first-party data (client records, CSVs, databases), which is what makes custom analysis and dashboarding easy.",
+    "Works across UK geography classifications via geography_type — from Output Areas (OA), LSOA and MSOA up to wards (WD), Local Authority Districts (LAD), counties, regions and countries, plus health (ICB/NHS), electoral and Travel-to-Work-Area (TTWA) geographies. Resolve postcodes/outcodes to the level you need first (postcodes_to_geography / outcode_to_geography), then join.",
+    "Typical analysis/map/dashboard workflow: load statistics (load_ons) and/or deprivation (load_imd), pull boundaries (load_geodata, then geodata_to_properties for a tidy frame), join all on geography_code, then choropleth/plot or export. See the 'Recipes for agents' docs page and the case studies for end-to-end examples.",
     "Bring your own DataFrame backend — narwhals returns pandas or polars depending on what is installed."
   ]
 }

--- a/docs/api/recipes.md
+++ b/docs/api/recipes.md
@@ -1,0 +1,105 @@
+# Recipes for agents
+
+Copy-paste snippets for the common tasks. Every connector returns a DataFrame
+(pandas or polars, depending on what you have installed) keyed on
+`geography_code` — that column is the universal join key across geography,
+statistics, deprivation and postcodes.
+
+## Install
+
+```bash
+uv add kindtech
+```
+
+## ONS statistics
+
+```python
+from kindtech.ons import load_ons
+
+# Friendly alias + geography_type — no NOMIS TYPE codes needed
+df = load_ons("population", geography_type="LAD", time="latest")
+
+# Raw NOMIS dataset id, with filters and column selection
+df = load_ons(
+    "NM_1_1",
+    geography_type="LAD",
+    time="latest",
+    measures=20100,
+    select=["geography_code", "geography_name", "obs_value"],
+)
+```
+
+## Geographic boundaries
+
+```python
+from kindtech.geo import load_geodata, geodata_to_properties
+
+# GeoJSON FeatureCollection for Local Authority Districts
+geo = load_geodata("LAD", year="2024", coverage="UK")
+
+# Flatten to rows with geography_code / geography_name ready to join
+rows = geodata_to_properties(geo, "LAD", 2024)
+```
+
+## Deprivation (IMD)
+
+```python
+from kindtech.imd import load_imd
+
+# Official England IoD 2025 (defaults: nation-level latest)
+imd = load_imd(nation="England")
+
+# Cross-nation comparison uses the mySociety composite
+uk = load_imd(nation="UK")  # year 2019
+```
+
+## Postcodes → geography
+
+```python
+from kindtech.postcodes import postcodes_to_geography, outcode_to_geography
+
+# Postcodes resolved to LSOA, ready to join on geography_code
+located = postcodes_to_geography(["SE13 7HX", "SE6 4RU"], geography_type="LSOA")
+
+# Outcodes (the prefix before the space) resolved to the LADs they span
+spans = outcode_to_geography(["SE13", "SE6"], geography_type="LAD")
+```
+
+## The join — combine sources on `geography_code`
+
+This is the pattern the [case studies](../case-studies/index.md) use: load each
+source, then merge on `geography_code`.
+
+```python
+import pandas as pd
+
+from kindtech.geo import geodata_to_properties, load_geodata
+from kindtech.imd import load_imd
+from kindtech.ons import load_ons
+
+# 1. Statistics and deprivation, both keyed on geography_code
+pop = load_ons("population", geography_type="LAD", time="latest")
+imd = load_imd(nation="England")
+
+# 2. Boundaries, flattened to the same key
+geo = load_geodata("LAD", year="2024", coverage="UK")
+shapes = pd.DataFrame(geodata_to_properties(geo, "LAD", 2024))
+
+# 3. Join everything on geography_code
+merged = (
+    shapes
+    .merge(pop, on="geography_code", how="left")
+    .merge(imd, on="geography_code", how="left")
+)
+```
+
+## Discovery helpers
+
+```python
+from kindtech.ons import list_tables
+from kindtech import list_dataset_aliases, list_geography_mappings
+
+list_tables(name="population")    # search the bundled NOMIS catalog
+list_dataset_aliases()            # friendly names → NOMIS dataset ids
+list_geography_mappings()         # geography_type → NOMIS TYPE codes
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
     - Postcodes: api/postcodes.md
     - Deprivation (IMD): api/imd.md
     - Data Sources: api/data-sources.md
+    - Recipes for agents: api/recipes.md
   - Blog:
     - blog/index.md
     - Introduction: blog/introduction.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,13 @@ dependencies = [
     "python-calamine>=0.2",
 ]
 
+[project.urls]
+Homepage = "https://kindtechuk.github.io/kindtech/"
+Documentation = "https://kindtechuk.github.io/kindtech/"
+Repository = "https://github.com/KindTechUK/kindtech"
+Issues = "https://github.com/KindTechUK/kindtech/issues"
+"llms.txt" = "https://kindtechuk.github.io/kindtech/llms.txt"
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 


### PR DESCRIPTION
## What
Makes KindTech discoverable along the path AI coding agents follow — PyPI metadata → docs → llms.txt → Context7 — building on the `/llms.txt` + `/llms-full.txt` we already generate. No MCP server (out of scope; docs/llms.txt-first).

Repo-side changes:
- **`pyproject.toml`** — add `[project.urls]` (Homepage, Documentation, Repository, Issues, and an explicit `llms.txt`) so PyPI surfaces the docs + machine-readable index.
- **`README.md`** — new "For AI agents / LLMs" section linking `/llms.txt`, `/llms-full.txt`, the Recipes page, and noting Context7 indexing.
- **`context7.json`** — root config telling Context7 how to index the repo (title, description, `folders: ["docs"]`, exclusions, and `rules` capturing the install + `geography_code` join workflow).
- **`docs/api/recipes.md`** — new "Recipes for agents" page: copy-paste snippets per connector plus the central `geography_code` join. Lives under `docs/api/` so the existing `llmstxt-md` glob auto-includes it in `/llms.txt` and `/llms-full.txt` (verified in a local build).
- **`mkdocs.yml`** — one nav line under User Guide.

## Verification
- `uv run mkdocs build` is clean; `site/api/recipes/` renders and the page appears in `site/llms.txt`.
- `context7.json` and `pyproject.toml` both parse.

## Manual follow-up after merge (can't be automated — web forms)
1. **Context7**: submit `https://github.com/KindTechUK/kindtech` at `https://context7.com/add-library?tab=github`. Context7 reads the default branch, so `context7.json` must be on `main` first.
2. **llms.txt directory**: list `https://kindtechuk.github.io/kindtech/llms.txt` at a public directory (e.g. directory.llmstxt.cloud).

Closes #39.

## Notes
- Leaves `[project].description` untouched to avoid colliding with the in-flight package-metadata work (#36).