### PR TITLE
Fix aged RoboRev findings

### DIFF
--- a/examples/geo_plus_ons.py
+++ b/examples/geo_plus_ons.py
@@ -198,16 +198,16 @@ def _(geojson, merged):
         zip(merged["geography_code"], merged["obs_value"], strict=False)
     )
 
-    # Build a geography_code → feature index so we don't rely
-    # on positional alignment between geojson and geo_df
+    # This example loads LAD 2024 boundaries above, so use the
+    # corresponding ArcGIS code field instead of guessing among
+    # potentially several properties ending in "CD".
+    code_field = "LAD24CD"
     code_to_feature: dict = {}
     for f in geojson["features"]:
         props = f.get("properties", {})
-        # Find the code field (ends with "CD", e.g. LAD24CD)
-        for key, val in props.items():
-            if key.endswith("CD") and val in code_to_value:
-                code_to_feature[val] = f
-                break
+        code = props.get(code_field)
+        if code in code_to_value:
+            code_to_feature[code] = f
 
     enriched = {
         "type": "FeatureCollection",

--- a/examples/geo_plus_ons.py
+++ b/examples/geo_plus_ons.py
@@ -78,6 +78,7 @@ def _(geo_button, geodata_to_properties, load_geodata, mo, pd):
 
     geojson = load_geodata(
         geography_type="LAD",
+        year="2024",
         boundary_type="BGC",
     )
     geo_df = pd.DataFrame(geodata_to_properties(geojson, "LAD", 2024))

--- a/src/kindtech/_mapping.py
+++ b/src/kindtech/_mapping.py
@@ -23,7 +23,11 @@ def extract_code(value: Any) -> str | None:
     """Extract string code from an enum or pass through a string."""
     if value is None:
         return None
-    return value.code if hasattr(value, "code") else value
+    code = value.code if hasattr(value, "code") else value
+    if not isinstance(code, str):
+        msg = f"Expected a string or enum-like code, got {type(value).__name__}"
+        raise TypeError(msg)
+    return code
 
 
 # Each value is a list of (min_year, max_year, nomis_type_code) tuples,
@@ -106,9 +110,10 @@ def resolve_dataset_id(dataset_id: str) -> str:
     Raises:
         ValueError: If the alias is not recognised.
     """
-    if dataset_id.startswith("NM_"):
-        return dataset_id
-    key = dataset_id.lower().strip()
+    cleaned = dataset_id.strip()
+    if cleaned.upper().startswith("NM_"):
+        return cleaned.upper()
+    key = cleaned.lower()
     if key in DATASET_ALIASES:
         return DATASET_ALIASES[key]
     available = ", ".join(sorted(DATASET_ALIASES))

--- a/src/kindtech/geo/api.py
+++ b/src/kindtech/geo/api.py
@@ -187,9 +187,11 @@ def geodata_to_properties(
                 stacklevel=2,
             )
             warned = True
-        row: dict[str, Any] = dict(props)
-        row["geography_code"] = code_val
-        row["geography_name"] = props.get(name_field, "")
+        row: dict[str, Any] = {
+            "geography_code": code_val,
+            "geography_name": props.get(name_field, ""),
+        }
+        row.update({key: value for key, value in props.items() if key not in row})
         rows.append(row)
     return rows
 

--- a/src/kindtech/geo/api.py
+++ b/src/kindtech/geo/api.py
@@ -21,6 +21,7 @@ Examples:
 """
 
 import logging
+import warnings
 from typing import Any
 
 import requests
@@ -177,8 +178,6 @@ def geodata_to_properties(
         props = feature.get("properties", {})
         code_val = props.get(code_field, "")
         if not code_val and not warned and props:
-            import warnings
-
             warnings.warn(
                 f"Field '{code_field}' not found in GeoJSON "
                 f"properties. Check that geography_type="
@@ -188,11 +187,9 @@ def geodata_to_properties(
                 stacklevel=2,
             )
             warned = True
-        row: dict[str, Any] = {
-            "geography_code": code_val,
-            "geography_name": props.get(name_field, ""),
-        }
-        row.update(props)
+        row: dict[str, Any] = dict(props)
+        row["geography_code"] = code_val
+        row["geography_name"] = props.get(name_field, "")
         rows.append(row)
     return rows
 

--- a/src/kindtech/ons/_ingestion.py
+++ b/src/kindtech/ons/_ingestion.py
@@ -29,7 +29,10 @@ DEFAULT_OUTPUT_PATH = Path(__file__).parent / "data" / "nomis_tables.csv"
 
 def _extract_source(keyfamily: dict) -> str:
     """Extract source name from a keyfamily's annotations."""
-    for annotation in keyfamily.get("annotations", {}).get("annotation", []):
+    annotations = keyfamily.get("annotations", {}).get("annotation", [])
+    if isinstance(annotations, dict):
+        annotations = [annotations]
+    for annotation in annotations:
         if (
             isinstance(annotation, dict)
             and annotation.get("annotationtitle") == "contenttype/sources"

--- a/src/kindtech/ons/api.py
+++ b/src/kindtech/ons/api.py
@@ -27,6 +27,7 @@ Examples:
 """
 
 import logging
+import re
 from typing import Any
 
 import narwhals.stable.v2 as nw
@@ -57,8 +58,9 @@ def _extract_year_from_time(time_value: Any) -> int | None:
     if time_value is None:
         return None
     s = str(time_value).strip()
-    if s.isdigit() and len(s) == 4:
-        return int(s)
+    match = re.match(r"^(\d{4})(?:$|\D)", s)
+    if match:
+        return int(match.group(1))
     return None
 
 

--- a/tests/test_geo_api.py
+++ b/tests/test_geo_api.py
@@ -254,6 +254,8 @@ def test_geodata_to_properties_basic():
                 "properties": {
                     "LAD24CD": "E06000001",
                     "LAD24NM": "Hartlepool",
+                    "geography_code": "source-value",
+                    "geography_name": "source-name",
                     "Shape__Area": 123.45,
                 }
             },
@@ -272,6 +274,7 @@ def test_geodata_to_properties_basic():
     assert len(rows) == 2
     assert rows[0]["geography_code"] == "E06000001"
     assert rows[0]["geography_name"] == "Hartlepool"
+    assert list(rows[0])[:2] == ["geography_code", "geography_name"]
     # Original properties are preserved
     assert rows[0]["LAD24CD"] == "E06000001"
     assert rows[0]["Shape__Area"] == 123.45

--- a/tests/test_geo_api.py
+++ b/tests/test_geo_api.py
@@ -325,5 +325,4 @@ def test_list_tables_top_level_import():
     """Test that list_tables is importable from top-level kindtech."""
     from kindtech import list_tables
 
-    result = list_tables()
-    assert len(result) > 0
+    assert callable(list_tables)

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -7,6 +7,7 @@ import unittest.mock as mock
 import pytest
 
 from kindtech._mapping import (
+    extract_code,
     geo_code_field,
     geo_name_field,
     list_dataset_aliases,
@@ -14,6 +15,11 @@ from kindtech._mapping import (
     resolve_dataset_id,
     resolve_nomis_geography,
 )
+
+
+def test_extract_code_rejects_non_string_values():
+    with pytest.raises(TypeError, match="Expected a string"):
+        extract_code(42)
 
 
 class TestResolveNomisGeography:
@@ -114,6 +120,9 @@ class TestResolveDatasetId:
 
     def test_nm_id_passthrough(self):
         assert resolve_dataset_id("NM_1_1") == "NM_1_1"
+
+    def test_nm_id_is_trimmed_and_normalised(self):
+        assert resolve_dataset_id(" nm_1_1 ") == "NM_1_1"
 
     def test_population_alias(self):
         assert resolve_dataset_id("population") == "NM_2002_1"

--- a/tests/test_ons_api.py
+++ b/tests/test_ons_api.py
@@ -12,8 +12,17 @@ import pytest
 import requests
 
 from kindtech.ons import list_tables, load_ons
+from kindtech.ons.api import _extract_year_from_time
 
 CSV_RESPONSE = "DATE,GEOGRAPHY_NAME,OBS_VALUE\n2023,England,12345\n2023,Wales,6789\n"
+
+
+@pytest.mark.parametrize(
+    ("time_value", "expected"),
+    [("2020", 2020), ("2018...2022", 2018), ("2020Q1", 2020), ("latest", None)],
+)
+def test_extract_year_from_time(time_value, expected):
+    assert _extract_year_from_time(time_value) == expected
 
 
 @mock.patch("kindtech.ons.api.requests.get")

--- a/tests/test_ons_ingestion.py
+++ b/tests/test_ons_ingestion.py
@@ -64,6 +64,18 @@ def test_extract_source_skips_non_dict_annotation() -> None:
     assert _extract_source(kf) == "Census"
 
 
+def test_extract_source_accepts_single_annotation_dict() -> None:
+    kf = {
+        "annotations": {
+            "annotation": {
+                "annotationtitle": "contenttype/sources",
+                "annotationtext": "Census",
+            },
+        },
+    }
+    assert _extract_source(kf) == "Census"
+
+
 def test_extract_source_missing_text_returns_empty() -> None:
     kf = {
         "annotations": {


### PR DESCRIPTION
## Summary

- make NOMIS ID and time parsing robust
- preserve normalized geography fields and avoid ambiguous map codes
- remove a live-network unit test and handle single NOMIS annotations

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q` (147 passed)

Independent scope audit: PASS.